### PR TITLE
Fix Articles List layout

### DIFF
--- a/html/com_content/category/default_articles.php
+++ b/html/com_content/category/default_articles.php
@@ -18,7 +18,6 @@ use Joomla\CMS\Language\Associations;
 HTMLHelper::addIncludePath( JPATH_COMPONENT . '/helpers/html' );
 
 // Create some shortcuts.
-$params    = &$this->item->params;
 $n         = count( $this->items );
 
 // Check for at least one editable article
@@ -240,7 +239,7 @@ $tableClass = $this->params->get( 'show_headings' ) != 1 ? ' table-noheader' : '
                 <?php } ?>
 
                 <?php if ( $isEditable ) { ?>
-                <td><?php if ( $article->params->get( 'access-edit' ) ) { echo HTMLHelper::_( 'icon.edit', $article, $params, ['class' => 'uk-button uk-button-link', 'data-uk-tooltip' => Text::_( 'JGLOBAL_EDIT_TITLE' ) ] ); } ?></td>
+                <td><?php if ( $article->params->get( 'access-edit' ) ) { echo HTMLHelper::_( 'icon.edit', $article, $article->params, ['class' => 'uk-button uk-button-link', 'data-uk-tooltip' => Text::_( 'JGLOBAL_EDIT_TITLE' ) ] ); } ?></td>
                 <?php } ?>
 
             </tr>


### PR DESCRIPTION
When using _Articles > List Layout_ such error comes up:

```
Warning: Creating default object from empty value in /xxx/templates/master3/html/com_content/category/default_articles.php on line ;21
```

This is because in list/ blog layouts there is no `$this->item` variable defined, but `$this->items`.
I've changed the code to read article params from each item object just as in default template here:

https://github.com/joomla/joomla-cms/blob/3.9.26/components/com_content/views/category/tmpl/default_articles.php#L277

By the way, great job!