### PR TITLE
Add editorconfig to the repo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
This adds [editorconfig](http://editorconfig.org/) file to the repository.
The motivation is to allow switching code style in editors which support editorconfig from Joomla CS (tabs) to this repo CS (spaces)

Probably file should be part of extension files as this template allows working with overrides within it's folder.