### PR TITLE
Fix Table Headings parameter effect in articles list layout

### DIFF
--- a/html/com_content/category/default_articles.php
+++ b/html/com_content/category/default_articles.php
@@ -36,7 +36,6 @@ if ( !empty( $this->items ) )
 }
 
 
-$tableClass = $this->params->get( 'show_headings' ) != 1 ? ' table-noheader' : '';
 ?>
 <form action="<?php echo htmlspecialchars( Uri::getInstance()->toString() ); ?>" method="post" name="adminForm" id="adminForm" class="uk-margin-medium-top">
 
@@ -89,7 +88,7 @@ $tableClass = $this->params->get( 'show_headings' ) != 1 ? ' table-noheader' : '
     ?>
     <table class="category uk-table uk-table-striped uk-table-responsive uk-table-hover<?php echo $tableClass; ?>">
         <caption class="uk-hidden"><?php echo Text::sprintf( 'COM_CONTENT_CATEGORY_LIST_TABLE_CAPTION', $this->category->title ); ?></caption>
-        <thead>
+        <thead <?php if ($this->params->get('show_headings') != 1) : ?>class="uk-hidden"<?php endif ?>>
             <tr>
 
                 <th><?php echo Text::_( 'JGLOBAL_TITLE' ); ?></th>


### PR DESCRIPTION
At this moment switching off the parameter _Table Headings_ in _Article Options > List Layouts_ has no effect, as it adds a `table-noheader` class to table which is not implemented (only in Protostar template).

This PR switches it with `uk-hidden` added to the `<thead>` element.