### PR TITLE
Fix retrieving class and labelClass values

### DIFF
--- a/html/layouts/com_fields/field/render.php
+++ b/html/layouts/com_fields/field/render.php
@@ -18,14 +18,15 @@ $field = $displayData['field'];
 $label = Text::_($field->label);
 $value = $field->value;
 $showLabel = $field->params->get('showlabel');
-$class = $displayData['class'];
+$labelClass = $field->params->get('label_render_class');
+$class = $field->params->get('render_class');
 
 if ($value == '') {
     return;
 }
 
 ?>
-<dt class="field-entry <?php echo $class; ?>">
+<dt class="field-entry <?php echo $labelClass; ?>">
     <?php if ($showLabel == 1) { ?>
     <span class="field-label"><?php echo htmlentities($label, ENT_QUOTES | ENT_IGNORE, 'UTF-8'); ?>: </span>
     <?php } ?>


### PR DESCRIPTION
When using custom fields inside an article (with Fields xtd button), php notice comes up:
```
Notice: Undefined index: class in /x/templates/master3/html/layouts/com_fields/field/render.php on line 21
```

This is because the `class` key is not defined in the `$displayData` array.

I've changed code to read `$class` and `$labelClass` from field parameters just as in original layout (https://github.com/joomla/joomla-cms/blob/3.9.27/components/com_fields/layouts/field/render.php)