### PR TITLE
Use file modified timestamp for custom asset versions

### DIFF
--- a/script/libraries/master3/config.php
+++ b/script/libraries/master3/config.php
@@ -463,7 +463,7 @@ final class Master3Config
                 $cssFile = realpath(Path::clean(JPATH_ROOT . '/templates/' . $this->name . '/css/' . htmlspecialchars(trim($cssFile->form->fName))));
                 if (is_file($cssFile) && strtolower(pathinfo($cssFile, PATHINFO_EXTENSION)) == 'css') {
                     $cssFile = str_replace('\\', '/', str_replace(JPATH_ROOT . DIRECTORY_SEPARATOR, '', $cssFile));
-                    HTMLHelper::stylesheet($cssFile, [], ['options' => ['version' => 'auto']]);
+                    HTMLHelper::stylesheet($cssFile, [], ['options' => ['version' => filemtime($cssFile)]]);
                 }
             }
         }
@@ -474,7 +474,7 @@ final class Master3Config
             $cssAddonFile = realpath(Path::clean(JPATH_ROOT . '/' . htmlspecialchars(trim($cssAddonFile))));
             if (is_file($cssAddonFile) && strtolower(pathinfo($cssAddonFile, PATHINFO_EXTENSION)) == 'css') {
                 $cssAddonFile = str_replace('\\', '/', str_replace(JPATH_ROOT . DIRECTORY_SEPARATOR, '', $cssAddonFile));
-                HTMLHelper::stylesheet($cssAddonFile, [], ['options' => ['version' => 'auto']]);
+                HTMLHelper::stylesheet($cssAddonFile, [], ['options' => ['version' => filemtime($cssAddonFile)]]);
             }
         }
 
@@ -504,7 +504,7 @@ final class Master3Config
                 $jsFile = realpath(Path::clean(JPATH_ROOT . '/templates/' . $this->name . '/js/' . htmlspecialchars(trim($jsFile->form->fName))));
                 if (is_file($jsFile) && strtolower(pathinfo($jsFile, PATHINFO_EXTENSION)) == 'js') {
                     $jsFile = str_replace('\\', '/', str_replace(JPATH_ROOT . DIRECTORY_SEPARATOR, '', $jsFile));
-                    HTMLHelper::script($jsFile, [], ['options' => ['version' => 'auto']]);
+                    HTMLHelper::script($jsFile, [], ['options' => ['version' => filemtime($jsFile)]]);
                 }
             }
         }
@@ -515,7 +515,7 @@ final class Master3Config
             $jsAddonFile = realpath(Path::clean(JPATH_ROOT . '/' . htmlspecialchars(trim($jsAddonFile))));
             if (is_file($jsAddonFile) && strtolower(pathinfo($jsAddonFile, PATHINFO_EXTENSION)) == 'js') {
                 $jsAddonFile = str_replace('\\', '/', str_replace(JPATH_ROOT . DIRECTORY_SEPARATOR, '', $jsAddonFile));
-                HTMLHelper::script($jsAddonFile, [], ['options' => ['version' => 'auto']]);
+                HTMLHelper::script($jsAddonFile, [], ['options' => ['version' => filemtime($jsAddonFile)]]);
             }
         }
 


### PR DESCRIPTION
At this moment all css and javascript files specified in the _Head includes_ tab are added to the document with `auto` version.
This string should be reserved to Joomla internal assets, as it's constant for current Joomla installation (see [Version::getMediaVersion](https://github.com/joomla/joomla-cms/blob/3.9.27/libraries/src/Version.php#L313))

In effect browser won't request new file after it's contents have changed.
This is particularly troublesome when using custom template modifications.

This PR uses files' modified timestamp as a version string.

Other solutions:

- Do not use any version (file will be requested every time but browser unless cache headers are set)

- Use md5 checksum for each file with [md5_file](https://www.php.net/manual/en/function.md5-file.php) function