### PR TITLE
Set main section width to 1-2 when one of the sidebars is on and has 1-2 width

### DIFF
--- a/script/libraries/master3/config.php
+++ b/script/libraries/master3/config.php
@@ -833,7 +833,7 @@ final class Master3Config
                         $section->mainGridSize = $countSidebarA && $countSidebarB ? '1-5' : '3-5';
                         break;
                     case '1-2':
-                        $section->mainGridSize = '1-1';
+                        $section->mainGridSize = $countSidebarA && $countSidebarB ? '1-1' : '1-2';
                         break;
                 }
             }


### PR DESCRIPTION
At this moment, when the Sidebars width is set to `1-2` and either Sidebar A or Sidebar B is visible, main content width is always set to `1-1`.
I think it makes sense only when both sidebars are visible, otherwise it's fine to split grid in half.